### PR TITLE
build: use GitHub CI to generate fonts for Windows

### DIFF
--- a/.github/workflows/generate-fonts-for-windows.yml
+++ b/.github/workflows/generate-fonts-for-windows.yml
@@ -1,0 +1,57 @@
+name: Generate fonts for Windows
+
+on:
+  # allow manually trigger
+  workflow_dispatch:
+
+jobs:
+  get-latest-tag:
+    name: Get latest tag
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ env.TAG }}
+    steps:
+      - name: Get latest release
+        uses: octokit/request-action@v2.x
+        id: get_latest_release
+        with:
+          route: GET /repos/13rac1/twemoji-color-font/releases/latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get the latest tag without v prefix
+        run: |
+          TAG_WITH_V_PREFIX=${{ fromJson(steps.get_latest_release.outputs.data).tag_name }}
+          echo "TAG=${TAG_WITH_V_PREFIX#v}" >> $GITHUB_ENV
+      - name: Summary
+        run: |
+          echo "Latest tag without v prefix is $TAG"
+
+  generate-fonts-for-windows:
+    name: Generate fonts for Windows
+    needs: get-latest-tag
+    runs-on: windows-latest
+    env:
+      TAG: ${{ needs.get-latest-tag.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Download latest version of twemoji-color-font from release page
+        uses: robinraju/release-downloader@v1.6
+        with:
+          repository: '13rac1/twemoji-color-font'
+          tag: 'v${{ env.TAG }}'
+          fileName: 'TwitterColorEmoji-SVGinOT-${{ env.TAG }}.zip'
+      - run: unzip TwitterColorEmoji-SVGinOT-${{ env.TAG }}.zip
+      - run: Copy-Item TwitterColorEmoji-SVGinOT-${{ env.TAG }}\TwitterColorEmoji-SVGinOT.ttf .\
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: Copy-Item .\windows\install.cmd .\
+      - run: .\install.cmd
+      - run: Get-ChildItem
+      - run: Copy-Item C:\Windows\Fonts\seguiemj.ttf .\
+      - run: Copy-Item C:\Windows\Fonts\seguisym.ttf .\
+      - name: Upload generated fonts and original fonts
+        uses: actions/upload-artifact@v3
+        with:
+          name: TwitterColorEmoji Fonts for Windows
+          path: '*.ttf'

--- a/windows/install.cmd
+++ b/windows/install.cmd
@@ -4,6 +4,11 @@ SETLOCAL
 @setlocal enableextensions
 @cd /d "%~dp0"
 
+REM We can use the following if statement to check if the script is being run by GitHub Actions
+IF "%GITHUB_ACTIONS%" == "true" (
+    ECHO INFO: script is being run by GitHub Actions
+)
+
 SET MS_EMOJI_FONT_PATH="%SystemRoot%\Fonts\seguiemj.ttf"
 SET MS_FONT_PATH="%SystemRoot%\Fonts\seguisym.ttf"
 SET EMOJI_FONT_PATH="%CD%\TwitterColorEmoji-SVGinOT.ttf"
@@ -101,6 +106,15 @@ IF EXIST %MS_EMOJI_FONT_PATH% (
     ECHO %MS_FONT_PATH%
     ECHO It is not overwritten, and can be reinstalled with uninstall.cmd
 )
+
+REM When the script is being run by GitHub Actions
+REM We skip font installation
+REM Because we only need the script to generate font files
+IF "%GITHUB_ACTIONS%" == "true" (
+    ECHO All Done!
+    EXIT /b
+)
+
 ECHO To finish installation, the font will be opened for you to install.
 ECHO.
 ECHO If the font is in a network path, copy to a local disk and


### PR DESCRIPTION
There are several issues reported that the Windows install script
does not work due to python, pip, or ttx cannot be found in the PATH.

For people who are not familiar with python development environment,
it might be too overwhelmed to setup the environment correctly.

So if we can directly provide a pre-built font files for Windows,
we should be able to make the Windows installation process simpler.
