### PR TITLE
Remove Outdated Brew Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,6 @@ A [Homebrew](https://brew.sh) package is available.
 # Tap the brew tap homebrew/cask-fonts keg (caskroom/fonts keg were moved into this).
 brew tap homebrew/cask-fonts
 # Install the font using brew
-brew cask install font-twitter-color-emoji
-# If that doesnt work, try...
 brew install --cask font-twitter-color-emoji
 ```
 


### PR DESCRIPTION
<!--
Thank you for making a pull request!

This project has a clean and consistent git history. Commit messages
must be in the following format to be merged:

tag: Title without period less than 50 characters

Comment body text, if needed, describing what and why wrapped to 72
characters.
-->
A small edit to the README to remove the outdated `brew cask install font-twitter-color-emoji` command, which no longer functioons.