### PR TITLE
install.cmd: support pyenv, fix potential %CD% bugs

### DIFF
--- a/windows/install.cmd
+++ b/windows/install.cmd
@@ -39,16 +39,16 @@ WHERE python /q || (
     GOTO :ERROR
 )
 
-WHERE pip.exe /q || (
+WHERE pip /q || (
     ECHO.
-    ECHO Pip.exe not found, install or add to PATH
+    ECHO Pip not found, install or add to PATH
     ECHO.
     GOTO :ERROR
 )
 
 ECHO Ensuring the latest FontTools is installed.
 
-pip.exe install --upgrade fonttools
+call pip install --upgrade fonttools
 
 WHERE ttx /q || (
     ECHO.
@@ -60,23 +60,23 @@ WHERE ttx /q || (
 PUSHD %TEMP%
 IF EXIST %MS_EMOJI_FONT_PATH% (
     ECHO Creating new Segoe UI Emoji font from Twitter Color Emoji
-    ttx -t "name" -o "emjname.ttx" %MS_EMOJI_FONT_PATH% || GOTO :ERROR
-    ttx -o %FINAL_EMJ_FONT_PATH% -m %EMOJI_FONT_PATH% "emjname.ttx" || GOTO :ERROR
-    DEL "emjname.ttx"
+    call ttx -t "name" -o "emjname.ttx" %MS_EMOJI_FONT_PATH% || GOTO :ERROR
+    call ttx -o %FINAL_EMJ_FONT_PATH% -m %EMOJI_FONT_PATH% "%CD%\emjname.ttx" || GOTO :ERROR
+    DEL "%CD%\emjname.ttx"
 )
 
 ECHO Creating new Segoe UI Symbol font from Twitter Color Emoji
 REM Merge Segoe UI Symbol into TwitterColorEmoji, this keeps
 REM TwitterColorEmoji's glyph ids intact for the 'SVG ' table data
-pyftmerge %EMOJI_FONT_PATH% %MS_FONT_PATH%
+call pyftmerge %EMOJI_FONT_PATH% %MS_FONT_PATH%
 ECHO Dumping SVG emojis
-ttx -t "SVG " -o "svg.ttx" %EMOJI_FONT_PATH% || GOTO :ERROR
-ttx -t "name" -o "name.ttx" %MS_FONT_PATH% || GOTO :ERROR
+call ttx -t "SVG " -o "svg.ttx" %EMOJI_FONT_PATH% || GOTO :ERROR
+call ttx -t "name" -o "name.ttx" %MS_FONT_PATH% || GOTO :ERROR
 ECHO Merging in dumped emojis
-ttx -o "almost.ttf" -m "merged.ttf" "name.ttx" || GOTO :ERROR
+call ttx -o "almost.ttf" -m "merged.ttf" "name.ttx" || GOTO :ERROR
 DEL "merged.ttf"
 DEL "name.ttx"
-ttx -o %FINAL_FONT_PATH% -m "almost.ttf" "svg.ttx" || GOTO :ERROR
+call ttx -o %FINAL_FONT_PATH% -m "almost.ttf" "svg.ttx" || GOTO :ERROR
 DEL "almost.ttf"
 DEL "svg.ttx"
 REM Get back to working directory.


### PR DESCRIPTION
<!--
Thank you for making a pull request!

This project has a clean and consistent git history. Commit messages
must be in the following format to be merged:

tag: Title without period less than 50 characters

Comment body text, if needed, describing what and why wrapped to 72
characters.
-->

I was having a bunch of issues with the install script, and had to tweak the bat file a bit for my purposes, mainly because I was using pyenv for my Python versioning.

I had an issue where I had `pip` and `ttx` as `.bat` files in the environment, not `.exe` files, so they would make the script exit early after being called if not called with `call`. 

Not entirely sure why I had to append `%CD%` where I did, though, some commands were ignoring the `pushd` command above.

I threw these changes rather hastily, so I'm putting them out here in order to discuss these sorts of issues and gather feedback, if there are any better solutions.